### PR TITLE
Add Moodle 5.1 compatibility

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -36,6 +36,12 @@ jobs:
       matrix:
         include:
           - php: '8.3'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: mariadb
+          - php: '8.3'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: pgsql
+          - php: '8.3'
             moodle-branch: 'MOODLE_500_STABLE'
             database: mariadb
           - php: '8.3'

--- a/classes/field_controller.php
+++ b/classes/field_controller.php
@@ -98,8 +98,6 @@ class field_controller extends \core_customfield\field_controller {
      * @throws coding_exception
      */
     public function config_form_validation(array $data, $files = []): array {
-        global $CFG;
-
         $errors = parent::config_form_validation($data, $files);
 
         if (preg_match($data['configdata']['regex'], '') === false) {
@@ -119,12 +117,14 @@ class field_controller extends \core_customfield\field_controller {
         if (isset($data['configdata']['link'])) {
             $link = $data['configdata']['link'];
             if (strlen($link)) {
-                require_once($CFG->dirroot . '/lib/validateurlsyntax.php');
                 if (strpos($link, '$$') === false) {
                     $errors['configdata[link]'] = get_string('errorconfiglinkplaceholder', 'customfield_textregex');
-                } else if (!validateUrlSyntax(str_replace('$$', 'XYZ', $link), 's+H?S?F-E-u-P-a?I?p?f?q?r?')) {
-                    // This validation is more strict than PARAM_URL - it requires the protocol and it must be either http or https.
-                    $errors['configdata[link]'] = get_string('errorconfiglinksyntax', 'customfield_textregex');
+                } else {
+                    $testurl = str_replace('$$', 'XYZ', $link);
+                    $cleaned = clean_param($testurl, PARAM_URL);
+                    if (empty($cleaned) || !preg_match('/^https?:\/\//i', $cleaned)) {
+                        $errors['configdata[link]'] = get_string('errorconfiglinksyntax', 'customfield_textregex');
+                    }
                 }
             }
         }

--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -35,7 +35,7 @@ use core_customfield\field_controller;
 use core_customfield\field_config_form;
 use stdClass;
 use coding_exception;
-use moodle_exception;
+use core\exception\moodle_exception;
 
 /**
  * Functional test for 'customfield_textregex'

--- a/version.php
+++ b/version.php
@@ -30,4 +30,4 @@ $plugin->version   = 2025041400;
 $plugin->requires  = 2021051718;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '1.1.1';
-$plugin->supported = [311, 500];
+$plugin->supported = [311, 501];


### PR DESCRIPTION
What this fixes:

- Updates $plugin->supported to include Moodle 5.1 (branch 501)
- Replaces deprecated validateUrlSyntax() (removed in Moodle 5.1) with clean_param(PARAM_URL) + http/https regex check and preserves the original validation strictness
- Updates use moodle_exception to namespaced use core\exception\moodle_exception in tests
- Adds MOODLE_501_STABLE to the CI matrix

 

>  Tested on a live Moodle 5.1 instance.